### PR TITLE
Added setOpacity function for production layer opacity

### DIFF
--- a/src/HeatLayer.js
+++ b/src/HeatLayer.js
@@ -72,6 +72,11 @@ L.HeatLayer = (L.Layer ? L.Layer : L.Class).extend({
         map.addLayer(this);
         return this;
     },
+    
+    // Added by DrillingInfo dev team
+    setOpacity: function (esOpacity) {
+        this._canvas.style['opacity'] = esOpacity;
+    },    
 
     _initCanvas: function () {
         var canvas = this._canvas = L.DomUtil.create('canvas', 'leaflet-heatmap-layer leaflet-layer');


### PR DESCRIPTION
Part of functionality for 'S14017 Opacity for production layer'. Sets CSS opacity property on heatmap canvas.
